### PR TITLE
Added WoolWars requirements

### DIFF
--- a/valid-requirements.json
+++ b/valid-requirements.json
@@ -77,6 +77,27 @@
         ]
     },
     {
+        "name": "WoolGames",
+        "apiType": "player",
+        "reqs": [
+            {
+                "path": "player.stats.WoolGames.wool_wars.stats.wins",
+                "id": "wool_wars_wins",
+                "name": "Woolwars Wins"
+            },
+            {
+                "path": "player.stats.WoolGames.wool_wars.stats.kills",
+                "id": "wool_wars_kills",
+                "name": "Woolwars Kills"
+            },
+            {
+                "path": "player.stats.Woolgames.wool_wars.stats.wool_placed",
+                "id": "wool_wars_wool_placed",
+                "name": "Woolwars Placed"
+            }
+        ]
+    },
+    {
         "name": "Skywars",
         "apiType": "player",
         "reqs": [


### PR DESCRIPTION
This PR adds three (3) Woolwars (WoolGames) requirements to the bot as a guild requirement, off by default using Hypixel API v2.

Thanks simply for helping me cause im an idiot.